### PR TITLE
Update Express Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/kyllynk/test-jenkins#readme",
   "dependencies": {
-    "express" : "*"
+    "express" : "^4.14.0"
   }
 }


### PR DESCRIPTION
Hi, express version is now equal to "*" so we have to pick specific version and 4.14.0 is good for now.